### PR TITLE
When force writing an applet, erase the old one

### DIFF
--- a/neotools/applet/manager.py
+++ b/neotools/applet/manager.py
@@ -28,10 +28,11 @@ def install_applet(device, content: bytes, force=False):
     if applet_type == AppletType.REGULAR:
         header = data_from_buf(APPLET_HEADER_FORMAT, content[0: APPLET_HEADER_FORMAT['size']])
 
-        if not force:
-            applet_list = read_applet_list(device)
-            if any(header['applet_id'] == applet['applet_id'] for applet in applet_list):
+        applet_list = read_applet_list(device)
+        if any(header['applet_id'] == applet['applet_id'] for applet in applet_list):
+            if not force:
                 raise NeotoolsError(f'Applet {header["name"]} is already installed')
+            remove_applet(device, header['applet_id'])
 
         required_size = header['ram_size'] + header['file_space']
         required_rom_size = header['rom_size']

--- a/neotools/cli.py
+++ b/neotools/cli.py
@@ -138,28 +138,34 @@ def fetch_applet(applet_id, path):
 
 
 @applets.command('remove-all')
-def remove_applets():
+@click.option('--yes', '-y', default=False, is_flag=True, help='No confirmation prompt')
+def remove_applets(yes):
     """ Delete all applets from the device. """
-    click.confirm(text='Are you sure you want to remove all applets?', abort=True)
+    if not yes:
+        click.confirm(text='Are you sure you want to remove all applets?', abort=True)
     commands.remove_applets()
 
 
 @applets.command('remove',
                  short_help="Experimental. Delete an applet from the device. Note that it does not free the space.")
 @click.argument('applet_id', type=BASED_INT)
-def remove_applet(applet_id):
+@click.option('--yes', '-y', default=False, is_flag=True, help='No confirmation prompt')
+def remove_applet(applet_id, yes):
     """ Delete an applet from the device. """
-    click.confirm(text='Are you sure you want to remove applet?' +
-                       'It will not free up the space and is meant only for development.', abort=True)
+    if not yes:
+        click.confirm(text='Are you sure you want to remove applet?' +
+                           'It will not free up the space and is meant only for development.', abort=True)
     commands.remove_applet(applet_id)
 
 
 @applets.command('install', short_help="Experimental. Install an applet. Use this at your own risk.")
 @click.argument('path', type=click.Path(exists=True, dir_okay=False))
 @click.option('--force', '-f', default=False, is_flag=True, help='Skip check if the applet exists')
-def install_applet(path, force):
-    click.confirm(text='Are you sure you want to install an applet? ' +
-                       'This is an experimental feature.', abort=True)
+@click.option('--yes', '-y', default=False, is_flag=True, help='No confirmation prompt')
+def install_applet(path, force, yes):
+    if not yes:
+        click.confirm(text='Are you sure you want to install an applet? ' +
+                           'This is an experimental feature.', abort=True)
     commands.install_applet(path, force)
 
 

--- a/neotools/cli.py
+++ b/neotools/cli.py
@@ -189,11 +189,12 @@ def read_all_files(applet_id, path, format_):
 
 
 @files.command('write')
+@applet_id_option()
 @click.argument('path', type=click.Path(exists=True, dir_okay=False))
 @file_name_or_space_arg()
-def write_file(path, file_name_or_space):
+def write_file(path, file_name_or_space, applet_id):
     contents = open(path).read()
-    commands.write_file(file_name_or_space, contents)
+    commands.write_file(applet_id, file_name_or_space, contents)
 
 
 @cli.command('info')

--- a/neotools/cli.py
+++ b/neotools/cli.py
@@ -19,8 +19,6 @@ class BasedIntParamType(click.ParamType):
         try:
             if value[:2].lower() == "0x":
                 return int(value[2:], 16)
-            elif value[:1] == "0":
-                return int(value, 8)
             return int(value, 10)
         except ValueError:
             self.fail(f"{value!r} is not a valid integer", param, ctx)

--- a/neotools/commands.py
+++ b/neotools/commands.py
@@ -147,15 +147,17 @@ def list_files(applet_id, verbose):
 
 
 @command_decorator
-def write_file(file_name_or_space, text):
-    with Device.connect() as device:
+def write_file(applet_id, file_name_or_space, text):
+    if applet_id == AppletIds.ALPHAWORD:
         text = import_text_to_neo(text)
+
+    with Device.connect() as device:
         device.dialogue_start()
-        file_attrs = file.get_file_by_name_or_space(device, AppletIds.ALPHAWORD, file_name_or_space)
+        file_attrs = file.get_file_by_name_or_space(device, applet_id, file_name_or_space)
         if file_attrs:
-            file.raw_write_file(device, text, AppletIds.ALPHAWORD, file_attrs.file_index, True)
+            file.raw_write_file(device, text, applet_id, file_attrs.file_index, True)
         else:
-            file.create_file(device, file_name_or_space, 'write', text, AppletIds.ALPHAWORD)
+            file.create_file(device, file_name_or_space, 'write', text, applet_id)
         device.dialogue_end()
 
 

--- a/neotools/commands.py
+++ b/neotools/commands.py
@@ -148,6 +148,8 @@ def list_files(applet_id, verbose):
 
 @command_decorator
 def write_file(applet_id, file_name_or_space, text):
+    if applet_id is None:
+        applet_id = AppletIds.ALPHAWORD
     if applet_id == AppletIds.ALPHAWORD:
         text = import_text_to_neo(text)
 

--- a/neotools/commands.py
+++ b/neotools/commands.py
@@ -149,11 +149,11 @@ def list_files(applet_id, verbose):
 @command_decorator
 def write_file(file_name_or_space, text):
     with Device.connect() as device:
-        raw_bytes = import_text_to_neo(text)
+        text = import_text_to_neo(text)
         device.dialogue_start()
         file_attrs = file.get_file_by_name_or_space(device, AppletIds.ALPHAWORD, file_name_or_space)
         if file_attrs:
-            file.raw_write_file(device, raw_bytes, AppletIds.ALPHAWORD, file_attrs.file_index, True)
+            file.raw_write_file(device, text, AppletIds.ALPHAWORD, file_attrs.file_index, True)
         else:
             file.create_file(device, file_name_or_space, 'write', text, AppletIds.ALPHAWORD)
         device.dialogue_end()

--- a/neotools/file.py
+++ b/neotools/file.py
@@ -224,7 +224,7 @@ def raw_write_file(device, buf, applet_id, file_index, raw):
     logger.info('Writing file complete')
 
 
-def create_file(device, filename, password, text, applet_id):
+def create_file(device, filename, password, data, applet_id):
     """
 
     Create a new file.
@@ -249,14 +249,14 @@ def create_file(device, filename, password, text, applet_id):
     :param device:
     :param filename:
     :param password:
-    :param text: The raw buffer to write.
+    :param data: The buffer to write.
     :param applet_id:
     :return: The new FileAttributes.
     """
     usage = get_applet_resource_usage(device, applet_id)
     available_space = get_available_space(device)
 
-    size = len(text)
+    size = len(data)
     if size + 1024 > available_space['free_ram']:
         # REVIEW: arbitrarily choosing to keep at least 1k unused on the device
         raise NeotoolsError('The device does not have enough RAM')
@@ -272,7 +272,7 @@ def create_file(device, filename, password, text, applet_id):
     # not sending it will still result in a new file, but the attributes will not be correct.
     message = Message(MessageConst.REQUEST_COMMIT, [(file_index, 4, 1), (applet_id, 5, 2)])
     send_message(device, message, MessageConst.RESPONSE_COMMIT)
-    raw_write_file(device, text, applet_id, file_index, True)
+    raw_write_file(device, data, applet_id, file_index, True)
     device.dialogue_end()
 
 

--- a/neotools/file.py
+++ b/neotools/file.py
@@ -224,7 +224,7 @@ def raw_write_file(device, buf, applet_id, file_index, raw):
     logger.info('Writing file complete')
 
 
-def create_file(device, filename, password, data, applet_id):
+def create_file(device, filename, password, text, applet_id):
     """
 
     Create a new file.
@@ -249,16 +249,14 @@ def create_file(device, filename, password, data, applet_id):
     :param device:
     :param filename:
     :param password:
-    :param data: The buffer to write.
+    :param text: The raw buffer to write.
     :param applet_id:
     :return: The new FileAttributes.
     """
     usage = get_applet_resource_usage(device, applet_id)
     available_space = get_available_space(device)
-    if isinstance(data, str):
-        data = data.encode('utf-8')
 
-    size = len(data)
+    size = len(text)
     if size + 1024 > available_space['free_ram']:
         # REVIEW: arbitrarily choosing to keep at least 1k unused on the device
         raise NeotoolsError('The device does not have enough RAM')
@@ -274,7 +272,7 @@ def create_file(device, filename, password, data, applet_id):
     # not sending it will still result in a new file, but the attributes will not be correct.
     message = Message(MessageConst.REQUEST_COMMIT, [(file_index, 4, 1), (applet_id, 5, 2)])
     send_message(device, message, MessageConst.RESPONSE_COMMIT)
-    raw_write_file(device, data, applet_id, file_index, True)
+    raw_write_file(device, text, applet_id, file_index, True)
     device.dialogue_end()
 
 


### PR DESCRIPTION
The existing behavior (don't check if applet exists) allows multiple applets of the same id to exist, which causes odd problems with the device's OS, and also neotools (referring to files, etc).

I couldn't think of a reason to retain the previous behavior, but if it is needed, maybe the option should be called "skip" or similar?